### PR TITLE
Conversion filters

### DIFF
--- a/src/histolab/filters/image_filters.py
+++ b/src/histolab/filters/image_filters.py
@@ -18,6 +18,7 @@
 
 from PIL import ImageOps
 
+from .. import util as U
 from . import image_filters_functional as F
 
 
@@ -37,6 +38,50 @@ class Compose(object):
         for f in self.filters:
             img = f(img)
         return img
+
+
+class ToPILImage(object):
+    """Convert a ndarray to a PIL Image, while preserving the value range.
+
+    Parameters
+    ----------
+    np_img : np.ndarray
+        The image represented as a NumPy array.
+
+    Returns
+    -------
+    PIL.Image.Image
+        The image represented as PIL Image
+    """
+
+    def __call__(self, np_img):
+        return U.np_to_pil(np_img)
+
+    def __repr__(self):
+        return self.__class__.__name__ + "()"
+
+
+class ApplyMaskImage(object):
+    """Mask image with the provided binary mask.
+
+    Parameters
+    ----------
+    img : Image.Image
+        Input image
+    mask : np.ndarray
+        Binary mask
+
+    Returns
+    -------
+    Image.Image
+        Image with the mask applied
+    """
+
+    def __init__(self, img):
+        self.img = img
+
+    def __call__(self, mask):
+        return U.apply_mask_image(self.img, mask)
 
 
 class Invert(object):
@@ -171,7 +216,7 @@ class HistogramEqualization(object):
     ----------
     img : PIL.Image.Image
         Input image.
-    nbins : iny. optional (default is 256)
+    n_bins : iny. optional (default is 256)
         Number of histogram bins.
 
     Returns

--- a/src/histolab/filters/image_filters.py
+++ b/src/histolab/filters/image_filters.py
@@ -216,7 +216,7 @@ class HistogramEqualization(object):
     ----------
     img : PIL.Image.Image
         Input image.
-    n_bins : iny. optional (default is 256)
+    n_bins : int. optional (default is 256)
         Number of histogram bins.
 
     Returns

--- a/src/histolab/util.py
+++ b/src/histolab/util.py
@@ -17,24 +17,26 @@
 # ------------------------------------------------------------------------
 import functools
 import operator
+from collections import deque, namedtuple
+from itertools import filterfalse as ifilterfalse
 from typing import List
 
 import numpy as np
-
-from itertools import filterfalse as ifilterfalse
-from collections import deque, namedtuple
-
 from PIL import Image, ImageDraw
 
 
 def np_to_pil(np_img: np.ndarray) -> Image.Image:
-    """ Convert a NumPy array to a PIL Image.
+    """Convert a NumPy array to a PIL Image.
 
-    Args:
-      np_img: The image represented as a NumPy array.
+    Parameters
+    ----------
+    np_img : np.ndarray 
+        The image represented as a NumPy array.
 
-    Returns:
-       Image.
+    Returns
+    -------
+    PIL.Image.Image
+        The image represented as PIL Image
     """
 
     def _transform_bool(image_array):

--- a/src/histolab/util.py
+++ b/src/histolab/util.py
@@ -30,7 +30,7 @@ def np_to_pil(np_img: np.ndarray) -> Image.Image:
 
     Parameters
     ----------
-    np_img : np.ndarray 
+    np_img : np.ndarray
         The image represented as a NumPy array.
 
     Returns

--- a/tests/unit/test_image_filters.py
+++ b/tests/unit/test_image_filters.py
@@ -5,7 +5,7 @@ import PIL
 
 from src.histolab.filters import image_filters as imf
 
-from ..unitutil import PILImageMock, function_mock
+from ..unitutil import NpArrayMock, PILImageMock, function_mock
 
 
 class DescribeImageFilters(object):
@@ -325,3 +325,29 @@ class DescribeImageFilters(object):
 
         F_blue_pen_filter.assert_called_once_with(image)
         assert type(blue_pen_filter(image)) == np.ndarray
+
+    def it_calls_np_to_pil(self, request):
+        array = NpArrayMock.ONES_30X30_UINT8
+        util_np_to_pil = function_mock(request, "src.histolab.util.np_to_pil")
+        util_np_to_pil.return_value = PIL.Image.fromarray(array)
+        to_pil_image = imf.ToPILImage()
+
+        to_pil_image(array)
+        print(util_np_to_pil.call_count)
+
+        util_np_to_pil.assert_called_once_with(array)
+        assert type(to_pil_image(array)) == PIL.Image.Image
+
+    def it_calls_apply_mask_image(self, request):
+        image = PILImageMock.DIMS_500X500_RGBA_COLOR_155_249_240
+        mask = NpArrayMock.ONES_500X500X4_BOOL
+        util_apply_mask_image = function_mock(
+            request, "src.histolab.util.apply_mask_image"
+        )
+        util_apply_mask_image.return_value = PIL.Image.fromarray(np.array(image) * mask)
+        class_apply_mask_image = imf.ApplyMaskImage(image)
+
+        class_apply_mask_image(mask)
+
+        util_apply_mask_image.assert_called_once_with(image, mask)
+        assert type(util_apply_mask_image(image, mask)) == PIL.Image.Image

--- a/tests/unit/test_slide.py
+++ b/tests/unit/test_slide.py
@@ -1,25 +1,25 @@
 # encoding: utf-8
 
 import os
+from unittest.mock import call
 
 import numpy as np
 import openslide
 import PIL
 import pytest
 from matplotlib.figure import Figure as matplotlib_figure
-from unittest.mock import call
 
 from src.histolab.slide import Slide, SlideSet
 
 from ..unitutil import (
-    dict_list_eq,
-    property_mock,
-    initializer_mock,
+    ANY,
+    PILImageMock,
     class_mock,
+    dict_list_eq,
+    initializer_mock,
     instance_mock,
     method_mock,
-    PILImageMock,
-    ANY,
+    property_mock,
 )
 
 
@@ -704,5 +704,5 @@ class Describe_Slideset(object):
         return property_mock(request, SlideSet, "_slides_dimensions_list")
 
     @pytest.fixture
-    def Slide_(selfs, request):
+    def Slide_(self, request):
         return class_mock(request, "src.histolab.slide.Slide")

--- a/tests/unitutil.py
+++ b/tests/unitutil.py
@@ -2,8 +2,8 @@
 
 """Functions that make mocking with pytest easier and more readable."""
 
-from unittest.mock import (ANY, PropertyMock, call, create_autospec,  # noqa
-                           patch)
+from unittest.mock import ANY, call  # noqa # isort:skip
+from unittest.mock import create_autospec, patch, PropertyMock  # isort:skip
 
 import numpy as np
 import PIL

--- a/tests/unitutil.py
+++ b/tests/unitutil.py
@@ -2,9 +2,11 @@
 
 """Functions that make mocking with pytest easier and more readable."""
 
+from unittest.mock import (ANY, PropertyMock, call, create_autospec,  # noqa
+                           patch)
+
+import numpy as np
 import PIL
-from unittest.mock import ANY, call  # noqa
-from unittest.mock import create_autospec, patch, PropertyMock
 
 
 def dict_list_eq(l1, l2):
@@ -86,3 +88,8 @@ class PILImageMock:
     DIMS_50X50_RGBA_COLOR_155_0_0 = PIL.Image.new(
         "RGBA", size=(50, 50), color=(155, 0, 0)
     )
+
+
+class NpArrayMock:
+    ONES_30X30_UINT8 = np.ones([30, 30], dtype="uint8")
+    ONES_500X500X4_BOOL = np.ones([500, 500, 4], dtype="bool")


### PR DESCRIPTION
Now is possible to fully compose image and morphological filters using a `Compose` object.

Example:
```python
from PIL import Image
from histolab.filters.morphological_filters import * 
from histolab.filters.image_filters import * 

im = Image.open("image.png")
c = Compose(
        [
            RgbToGrayscale(),
            OtsuThreshold(),
            BinaryDilation(),
            RemoveSmallHoles(),
            BinaryDilation(),
            ApplyMaskImage(im),
        ]
    )
result = c(im)
result.save("result.png")
```